### PR TITLE
Unpin zeroize dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = ">=1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]


### PR DESCRIPTION
The pin of zeroize `<1.4` caused issues with my dependency list. I understand the interest to maintain the MSRV, but I think MSRV should be guaranteed by adding a `Cargo.lock` to crates that use this crate. In my opinion, constraining the upper-bound only makes sense if the crate to depend on (in this case `zeroize`) somehow violated semantic versioning and introduced a breaking change in a minor version. This is (as far as I have seen) not the case. Thus, I would suggest removing the upper-bound; the MSRV still holds as one can choose lower versions of zeroize in the `Cargo.toml` or `Cargo.lock` in crates using this version of `curve25519-dalek`.