### PR TITLE
Add {EdwardsPoint, RistrettoPoint}::mul_small_scalar

### DIFF
--- a/curve25519-dalek/src/backend/mod.rs
+++ b/curve25519-dalek/src/backend/mod.rs
@@ -167,7 +167,7 @@ impl VartimePrecomputedStraus {
 
 #[allow(missing_docs)]
 #[cfg(feature = "alloc")]
-pub fn straus_multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
+pub fn straus_multiscalar_mul<I, J, const N: usize>(scalars: I, points: J) -> EdwardsPoint
 where
     I: IntoIterator,
     I::Item: core::borrow::Borrow<Scalar>,
@@ -179,19 +179,19 @@ where
     match get_selected_backend() {
         #[cfg(curve25519_dalek_backend = "simd")]
         BackendKind::Avx2 => {
-            self::vector::scalar_mul::straus::spec_avx2::Straus::multiscalar_mul::<I, J>(
+            self::vector::scalar_mul::straus::spec_avx2::Straus::<N>::multiscalar_mul::<I, J>(
                 scalars, points,
             )
         }
         #[cfg(all(curve25519_dalek_backend = "simd", nightly))]
         BackendKind::Avx512 => {
-            self::vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::multiscalar_mul::<
+            self::vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::<N>::multiscalar_mul::<
                 I,
                 J,
             >(scalars, points)
         }
         BackendKind::Serial => {
-            self::serial::scalar_mul::straus::Straus::multiscalar_mul::<I, J>(scalars, points)
+            self::serial::scalar_mul::straus::Straus::<N>::multiscalar_mul::<I, J>(scalars, points)
         }
     }
 }
@@ -237,7 +237,7 @@ pub fn variable_base_mul(point: &EdwardsPoint, scalar: &Scalar) -> EdwardsPoint 
         BackendKind::Avx512 => {
             self::vector::scalar_mul::variable_base::spec_avx512ifma_avx512vl::mul(point, scalar)
         }
-        BackendKind::Serial => self::serial::scalar_mul::variable_base::mul(point, scalar),
+        BackendKind::Serial => self::serial::scalar_mul::variable_base::mul::<64>(point, scalar),
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
@@ -44,9 +44,12 @@ use crate::traits::VartimeMultiscalarMul;
 ///
 /// [solution]: https://www.jstor.org/stable/2310929
 /// [problem]: https://www.jstor.org/stable/2312273
-pub struct Straus {}
+///
+/// MODIFIED BY SIGNAL: The generic parameter `N` is the maximum number of **nibbles** in a scalar,
+/// with the top bit of the top nibble clear. See [`Scalar::as_radix_16`].
+pub struct Straus<const N: usize = 64> {}
 
-impl MultiscalarMul for Straus {
+impl<const N: usize> MultiscalarMul for Straus<N> {
     type Point = EdwardsPoint;
 
     /// Constant-time Straus using a fixed window of size \\(4\\).
@@ -122,11 +125,11 @@ impl MultiscalarMul for Straus {
         #[cfg_attr(not(feature = "zeroize"), allow(unused_mut))]
         let mut scalar_digits: Vec<_> = scalars
             .into_iter()
-            .map(|s| s.borrow().as_radix_16())
+            .map(|s| s.borrow().as_radix_16::<N>())
             .collect();
 
         let mut Q = EdwardsPoint::identity();
-        for j in (0..64).rev() {
+        for j in (0..N).rev() {
             Q = Q.mul_by_pow_2(4);
             let it = scalar_digits.iter().zip(lookup_tables.iter());
             for (s_i, lookup_table_i) in it {
@@ -144,7 +147,7 @@ impl MultiscalarMul for Straus {
     }
 }
 
-impl VartimeMultiscalarMul for Straus {
+impl VartimeMultiscalarMul for Straus<64> {
     type Point = EdwardsPoint;
 
     /// Variable-time Straus using a non-adjacent form of width \\(5\\).

--- a/curve25519-dalek/src/backend/vector/scalar_mul/variable_base.rs
+++ b/curve25519-dalek/src/backend/vector/scalar_mul/variable_base.rs
@@ -26,7 +26,7 @@ pub mod spec {
         //    s = s_0 + s_1*16^1 + ... + s_63*16^63,
         //
         // with `-8 ≤ s_i < 8` for `0 ≤ i < 63` and `-8 ≤ s_63 ≤ 8`.
-        let scalar_digits = scalar.as_radix_16();
+        let scalar_digits = scalar.as_radix_16::<64>();
         // Compute s*P as
         //
         //    s*P = P*(s_0 +   s_1*16^1 +   s_2*16^2 + ... +   s_63*16^63)

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -960,6 +960,34 @@ impl RistrettoPoint {
             scalar * constants::RISTRETTO_BASEPOINT_TABLE
         }
     }
+
+    /// Limited scalar multiplication: compute `scalar * self` when `scalar` is known to be less
+    /// than 2^127.
+    ///
+    /// This is still constant-time.
+    pub fn mul_small_scalar(&self, scalar: &Scalar) -> Self {
+        RistrettoPoint(self.0.mul_small_scalar(scalar))
+    }
+
+    /// Limited multiscalar multiplication: compute `sum(s_i * P)` when every `s_i` is known to be
+    /// less than 2^127.
+    ///
+    /// Equivalent to [`MultiscalarMul::multiscalar_mul`] on `RistrettoPoint`s, but faster, while
+    /// still being constant-time.
+    #[cfg(feature = "alloc")]
+    pub fn multiscalar_mul_small_scalars<I, J>(scalars: I, points: J) -> RistrettoPoint
+    where
+        I: IntoIterator,
+        I::Item: Borrow<Scalar>,
+        J: IntoIterator,
+        J::Item: Borrow<RistrettoPoint>,
+    {
+        let extended_points = points.into_iter().map(|P| P.borrow().0);
+        RistrettoPoint(EdwardsPoint::multiscalar_mul_small_scalars(
+            scalars,
+            extended_points,
+        ))
+    }
 }
 
 define_mul_assign_variants!(LHS = RistrettoPoint, RHS = Scalar);


### PR DESCRIPTION
(and `multiscalar_mul_small_scalars`)

There are many applications where scalars may be statically known to be less than the full range of the Ristretto group. In those cases, multiplication can be done more cheaply while still being constant-time. `mul_small_scalar` and `multiscalar_mul_small_scalars` expose that functionality for scalars strictly less than 2^127.